### PR TITLE
Providers::NginxSite: set of default matchers

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,18 @@
+if defined?(ChefSpec)
+  def add_nginx_site(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:nginx_site, :create, resource_name)
+  end
+
+  def remove_nginx_site(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:nginx_site, :delete, resource_name)
+  end
+
+  def enable_nginx_site(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:nginx_site, :enable, resource_name)
+  end
+
+  def disable_nginx_site(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:nginx_site, :disable, resource_name)
+  end
+
+end


### PR DESCRIPTION
Use it this way:

**recipe**

``` ruby
nginx_site "groupon-application" do
  template "vhost.erb"
  variables(root: '/home/groupon/groupon/current/public')
  action :create
end
```

**spec**

``` ruby
it { is_expected.to add_nginx_site 'example.com' }
```

or

``` ruby
it "should add nginx site 'groupon-application'" do
  expect(subject).to add_nginx_site 'example.com'
end
```
